### PR TITLE
Add restricted group example

### DIFF
--- a/examples/restrictedgroup.osc.yaml
+++ b/examples/restrictedgroup.osc.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+$schema: https://aka.ms/osc/schemas/prerelease/document.json
+resources:
+- name: ConfigureGroupMembership
+  type: Microsoft.Windows/CSP
+  properties:
+    path: ./Device/Vendor/MSFT/Policy/Config/RestrictedGroups/ConfigureGroupMembership
+    type: string
+    value: |
+      <groupmembership>
+        <accessgroup desc="Administrators">
+          <member name="Administrator"/>
+        </accessgroup>
+      </groupmembership>

--- a/examples/restrictedgroup.osc.yaml
+++ b/examples/restrictedgroup.osc.yaml
@@ -1,14 +1,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 $schema: https://aka.ms/osc/schemas/prerelease/document.json
 resources:
-- name: ConfigureGroupMembership
+- name: Configure
   type: Microsoft.Windows/CSP
   properties:
-    path: ./Device/Vendor/MSFT/Policy/Config/RestrictedGroups/ConfigureGroupMembership
+    path: ./Device/Vendor/MSFT/Policy/Config/LocalUsersAndGroups/Configure
     type: string
     value: |
-      <groupmembership>
+      <GroupConfiguration>
         <accessgroup desc="Administrators">
-          <member name="Administrator"/>
+          <group action="R" />
+          <add member="Administrator"/>
         </accessgroup>
-      </groupmembership>
+      </GroupConfiguration>


### PR DESCRIPTION
Add restricted group example.
Using LocalUsersAndGroups policy instead of the RestrictedGroups policy from suggestion: 
https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-localusersandgroups#:~:text=Starting%20from%20Windows%2010%2C%20version%2020H2%2C%20it%20is%20recommended%20to%20use%20the%20LocalUsersAndGroups%20policy%20instead%20of%20the%20RestrictedGroups%20policy.%20Applying%20both%20the%20policies%20to%20the%20same%20device%20is%20unsupported%20and%20may%20yield%20unpredictable%20results.
<img width="978" height="518" alt="image" src="https://github.com/user-attachments/assets/1f3bc651-a856-4e39-b064-c33778f8ec47" />
<img width="1334" height="375" alt="image" src="https://github.com/user-attachments/assets/91819d9b-7372-463d-abf5-856b02fbdc88" />


